### PR TITLE
Trying to use flink-spector on my flink scala project.

### DIFF
--- a/flinkspector-core/pom.xml
+++ b/flinkspector-core/pom.xml
@@ -25,7 +25,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>flinkspector-core</artifactId>
+    <artifactId>flinkspector-core_${scala.binary.version}</artifactId>
 
     <build>
         <plugins>

--- a/flinkspector-dataset/pom.xml
+++ b/flinkspector-dataset/pom.xml
@@ -25,17 +25,17 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>flinkspector-dataset</artifactId>
+    <artifactId>flinkspector-dataset_${scala.binary.version}</artifactId>
 
     <dependencies>
         <dependency>
             <groupId>org.flinkspector</groupId>
-            <artifactId>flinkspector-core</artifactId>
+            <artifactId>flinkspector-core_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-java</artifactId>
+            <artifactId>flink-java_${scala.binary.version}</artifactId>
             <version>${flink.version}</version>
         </dependency>
     </dependencies>

--- a/flinkspector-datastream/pom.xml
+++ b/flinkspector-datastream/pom.xml
@@ -25,23 +25,23 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>flinkspector-datastream</artifactId>
+    <artifactId>flinkspector-datastream_${scala.binary.version}</artifactId>
 
     <dependencies>
         <dependency>
             <groupId>org.flinkspector</groupId>
-            <artifactId>flinkspector-core</artifactId>
+            <artifactId>flinkspector-core_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-java</artifactId>
+            <artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
             <version>${flink.version}</version>
             <type>test-jar</type>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-java</artifactId>
+            <artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
             <version>${flink.version}</version>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
         <slf4j.version>1.7.7</slf4j.version>
         <guava.version>18.0</guava.version>
         <!-- Default scala versions, may be overwritten by build profiles -->
-        <scala.version>2.10.4</scala.version>
-        <scala.binary.version>2.10</scala.binary.version>
+        <scala.version>2.11.7</scala.version>
+        <scala.binary.version>2.11</scala.binary.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -45,13 +45,13 @@
         <!-- flink -->
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-runtime</artifactId>
+            <artifactId>flink-runtime_${scala.binary.version}</artifactId>
             <version>${flink.version}</version>
             <type>test-jar</type>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-test-utils</artifactId>
+            <artifactId>flink-test-utils_${scala.binary.version}</artifactId>
             <version>${flink.version}</version>
         </dependency>
         <!-- zeromq -->


### PR DESCRIPTION
More is probably needed to make flink-spector work seamlessly with scala, but this works for me for now, and is hopefully a (very small) step in the right direction. 

Below are the lines that I needed to add to my build.sbt file to get the [WindowingTest example](https://github.com/ottogroup/flink-spector/blob/master/flinkspector-datastream/src/test/java/org/flinkspector/datastream/examples/WindowingTest.java) to work. It may be worth adding this info to the documentation:

    libraryDependencies ++= Seq(
      "junit" % "junit" % "4.12" % "test",
      "org.flinkspector" % "flinkspector-datastream_2.11" % "0.1-SNAPSHOT" % "test",
      "org.apache.flink" % "flink-streaming-java_2.11" % "0.10.1" % "test" classifier "tests",
      "org.apache.flink" % "flink-core_2.11" % "0.10.1" % "test" classifier "tests",
      "org.apache.flink" % "flink-runtime_2.11" % "0.10.1" % "test" classifier "tests",
      "org.hamcrest" % "hamcrest-all" % "1.3" % "test"
     )
    resolvers += "Local Maven Repository" at "file://"+Path.userHome.absolutePath+"/.m2/repository"

PS: eagerly waiting for scalatest support :-)