### PR TITLE
Fixed repeat semantics of Event-time input builder 

### DIFF
--- a/flinkspector-datastream/src/main/java/org/flinkspector/datastream/StreamTestBase.java
+++ b/flinkspector-datastream/src/main/java/org/flinkspector/datastream/StreamTestBase.java
@@ -247,7 +247,7 @@ public class StreamTestBase {
 	 * @param unit of time.
 	 * @return {@link org.flinkspector.datastream.input.time.InWindow}
 	 */
-	public static InWindow inWindow(long time, TimeUnit unit) {
+	public static InWindow intoWindow(long time, TimeUnit unit) {
 		return InWindow.to(time, unit);
 	}
 

--- a/flinkspector-datastream/src/main/java/org/flinkspector/datastream/input/time/InWindow.java
+++ b/flinkspector-datastream/src/main/java/org/flinkspector/datastream/input/time/InWindow.java
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Sets the timestamp of a record to a value which fits into a certain window.
  */
-public class InWindow implements Moment {
+public class InWindow extends Moment {
 
 	private final long timeSpan;
 
@@ -36,5 +36,10 @@ public class InWindow implements Moment {
 	@Override
 	public long getTimestamp(long currentTimestamp) {
 		return timeSpan - 1;
+	}
+
+	@Override
+	public long getShift() {
+		return 1;
 	}
 }

--- a/flinkspector-datastream/src/main/java/org/flinkspector/datastream/input/time/Instant.java
+++ b/flinkspector-datastream/src/main/java/org/flinkspector/datastream/input/time/Instant.java
@@ -16,16 +16,11 @@
 
 package org.flinkspector.datastream.input.time;
 
-public abstract class TimeSpan extends Moment {
-
-	/**
-	 * Getter for defined time span
-	 * @return time span in milliseconds
-	 */
-	public abstract long getTimeSpan();
+public class Instant extends TimeSpan {
 
 	@Override
-	public long getTimestamp(long currentTimestamp) {
-		return currentTimestamp + getTimeSpan();
+	public long getTimeSpan() {
+		return 0;
 	}
+
 }

--- a/flinkspector-datastream/src/main/java/org/flinkspector/datastream/input/time/Moment.java
+++ b/flinkspector-datastream/src/main/java/org/flinkspector/datastream/input/time/Moment.java
@@ -19,7 +19,7 @@ package org.flinkspector.datastream.input.time;
 /**
  * Specifies a moment for a record to generate a timestamp.
  */
-public interface Moment {
+public abstract class Moment {
 
 	/**
 	 * Getter for defined time span
@@ -27,6 +27,9 @@ public interface Moment {
 	 *
 	 * @return time span in milliseconds
 	 */
-	long getTimestamp(long currentTimestamp);
+	public abstract long getTimestamp(long currentTimestamp);
 
+	public long getShift() {
+		return 0;
+	}
 }

--- a/flinkspector-datastream/src/test/java/org/flinkspector/datastream/functions/ParrallelFromStreamRecordsTest.java
+++ b/flinkspector-datastream/src/test/java/org/flinkspector/datastream/functions/ParrallelFromStreamRecordsTest.java
@@ -33,7 +33,7 @@ public class ParrallelFromStreamRecordsTest extends StreamTestBase {
 		EventTimeInput<Integer> input = EventTimeInputBuilder
 				.startWith(1)
 				.emit(1)
-				.emit(1, inWindow(2, minutes))
+				.emit(1, intoWindow(2, minutes))
 				.emit(2, after(30, seconds))
 				.flushOpenWindowsOnTermination();
 

--- a/flinkspector-datastream/src/test/scala/org/flinkspector/datastream/input/EventTimeInputBuilderSpec.scala
+++ b/flinkspector-datastream/src/test/scala/org/flinkspector/datastream/input/EventTimeInputBuilderSpec.scala
@@ -33,7 +33,6 @@ class EventTimeInputBuilderSpec extends CoreSpec {
 
   }
 
-
   "the builder" should "repeat a input list one times" in
     new EventTimeInputBuilderCase {
       builder.repeatAll(After.period(2, TimeUnit.SECONDS), 1)
@@ -49,7 +48,7 @@ class EventTimeInputBuilderSpec extends CoreSpec {
       )
     }
 
-  "the builder" should "set flushWindows" in
+  it should "set flushWindows" in
     new EventTimeInputBuilderCase {
 
       builder.getFlushWindowsSetting shouldBe false
@@ -57,7 +56,7 @@ class EventTimeInputBuilderSpec extends CoreSpec {
       builder.getFlushWindowsSetting shouldBe true
     }
 
-  "the builder" should "repeat a input list two times" in
+  it should "repeat a input list two times" in
     new EventTimeInputBuilderCase {
       builder.repeatAll(After.period(2, TimeUnit.SECONDS), 2)
       builder.getInput.toList shouldBe List(
@@ -76,9 +75,9 @@ class EventTimeInputBuilderSpec extends CoreSpec {
       )
     }
 
-  "the builder" should "repeat an element four times" in {
+  it should "repeat an element four times" in {
     val builder = EventTimeInputBuilder.startWith(1)
-      .emit(2,After.period(1,TimeUnit.SECONDS),4)
+      .emit(2, After.period(1, TimeUnit.SECONDS), 4)
 
     builder.getInput.toList shouldBe List(
       new StreamRecord[Integer](1, 0),
@@ -89,26 +88,227 @@ class EventTimeInputBuilderSpec extends CoreSpec {
     )
   }
 
-  "the builder" should "put elements in windows" in {
+  it should "put elements in windows" in {
     val builder = EventTimeInputBuilder.startWith(1)
-      .emit(2,InWindow.to(1,TimeUnit.SECONDS))
+      .emit(2, InWindow.to(1, TimeUnit.SECONDS))
+      .emit(3)
 
     builder.getInput.toList shouldBe List(
       new StreamRecord[Integer](1, 0),
-      new StreamRecord[Integer](2, 999)
+      new StreamRecord[Integer](2, 999),
+      new StreamRecord[Integer](3, 1000)
     )
   }
 
-  "the builder" should "repeat elements in windows" in {
+  it should "repeat elements in nested windows" in {
     val builder = EventTimeInputBuilder.startWith(1)
-      .emit(2,InWindow.to(1,TimeUnit.SECONDS),3)
+      .emit(2, InWindow.to(1, TimeUnit.SECONDS))
+      .emit(3)
+      .repeatAll(After.period(0, TimeUnit.DAYS), 2)
+
+    builder.getInput.toList shouldBe List(
+      new StreamRecord[Integer](1, 0),
+      new StreamRecord[Integer](2, 999),
+      new StreamRecord[Integer](3, 1000),
+      new StreamRecord[Integer](1, 1000),
+      new StreamRecord[Integer](2, 1999),
+      new StreamRecord[Integer](3, 2000),
+      new StreamRecord[Integer](1, 2000),
+      new StreamRecord[Integer](2, 2999),
+      new StreamRecord[Integer](3, 3000)
+    )
+  }
+
+  it should "repeat elements with appended window" in {
+    val builder = EventTimeInputBuilder.startWith(1)
+      .emit(2, After.period(1, TimeUnit.SECONDS))
+      .emit(3, InWindow.to(2, TimeUnit.SECONDS))
+      .repeatAll(After.period(0, TimeUnit.DAYS), 1)
+
+    builder.getInput.toList shouldBe List(
+      new StreamRecord[Integer](1, 0),
+      new StreamRecord[Integer](2, 1000),
+      new StreamRecord[Integer](3, 1999),
+      new StreamRecord[Integer](1, 2000),
+      new StreamRecord[Integer](2, 3000),
+      new StreamRecord[Integer](3, 3999)
+    )
+  }
+
+  it should "repeat elements in windows" in {
+    val builder = EventTimeInputBuilder.startWith(1)
+      .emit(2, InWindow.to(1, TimeUnit.SECONDS), 3)
+      .emit(3)
 
     builder.getInput.toList shouldBe List(
       new StreamRecord[Integer](1, 0),
       new StreamRecord[Integer](2, 999),
       new StreamRecord[Integer](2, 999),
-      new StreamRecord[Integer](2, 999)
+      new StreamRecord[Integer](2, 999),
+      new StreamRecord[Integer](3, 1000)
     )
   }
+
+  it should "repeat elements with windows in front" in {
+    val builder = EventTimeInputBuilder.startWith(1, InWindow.to(2, TimeUnit.SECONDS))
+      .repeatAll(After.period(0, TimeUnit.SECONDS), 2)
+
+    builder.getInput.toList shouldBe List(
+      new StreamRecord[Integer](1, 1999),
+      new StreamRecord[Integer](1, 2000),
+      new StreamRecord[Integer](1, 2000)
+    )
+  }
+
+  it should "repeat elements with windows in front and back" in {
+    val builder = EventTimeInputBuilder.startWith(1, InWindow.to(2, TimeUnit.SECONDS))
+      .emit(2, InWindow.to(4, TimeUnit.SECONDS))
+      .repeatAll(After.period(0, TimeUnit.SECONDS), 2)
+
+    builder.getInput.toList shouldBe List(
+      new StreamRecord[Integer](1, 1999),
+      new StreamRecord[Integer](2, 3999),
+      new StreamRecord[Integer](1, 4000),
+      new StreamRecord[Integer](2, 5999),
+      new StreamRecord[Integer](1, 6000),
+      new StreamRecord[Integer](2, 7999)
+    )
+  }
+
+  it should "repeat elements with windows in back" in {
+    val builder = EventTimeInputBuilder.startWith(1)
+      .emit(2, InWindow.to(2, TimeUnit.SECONDS))
+      .repeatAll(After.period(0, TimeUnit.SECONDS), 2)
+
+    builder.getInput.toList shouldBe List(
+      new StreamRecord[Integer](1, 0),
+      new StreamRecord[Integer](2, 1999),
+      new StreamRecord[Integer](1, 2000),
+      new StreamRecord[Integer](2, 3999),
+      new StreamRecord[Integer](1, 4000),
+      new StreamRecord[Integer](2, 5999)
+    )
+  }
+
+  it should "repeat elements with windows in back using Instant" in {
+    val builder = EventTimeInputBuilder.startWith(1)
+      .emit(2, InWindow.to(2, TimeUnit.SECONDS))
+      .repeatAll(2)
+
+    builder.getInput.toList shouldBe List(
+      new StreamRecord[Integer](1, 0),
+      new StreamRecord[Integer](2, 1999),
+      new StreamRecord[Integer](1, 2000),
+      new StreamRecord[Integer](2, 3999),
+      new StreamRecord[Integer](1, 4000),
+      new StreamRecord[Integer](2, 5999)
+    )
+  }
+
+  it should "repeat elements using Instant" in {
+    val builder = EventTimeInputBuilder.startWith(1, After.period(1, TimeUnit.SECONDS))
+      .repeatAll(5)
+
+    builder.getInput.toList shouldBe List(
+      new StreamRecord[Integer](1, 1000),
+      new StreamRecord[Integer](1, 1000),
+      new StreamRecord[Integer](1, 1000),
+      new StreamRecord[Integer](1, 1000),
+      new StreamRecord[Integer](1, 1000),
+      new StreamRecord[Integer](1, 1000)
+    )
+  }
+
+  it should "repeat elements with windows in back with time in between" in {
+    val builder = EventTimeInputBuilder.startWith(1)
+      .emit(2, InWindow.to(2, TimeUnit.SECONDS))
+      .repeatAll(After.period(1, TimeUnit.SECONDS), 2)
+
+    builder.getInput.toList shouldBe List(
+      new StreamRecord[Integer](1, 0),
+      new StreamRecord[Integer](2, 1999),
+      new StreamRecord[Integer](1, 3000),
+      new StreamRecord[Integer](2, 4999),
+      new StreamRecord[Integer](1, 6000),
+      new StreamRecord[Integer](2, 7999)
+    )
+  }
+
+  it should "repeat elements with windows in back with double repeat" in {
+    val builder = EventTimeInputBuilder.startWith(1)
+      .emit(2, InWindow.to(2, TimeUnit.SECONDS))
+      .repeatAll(After.period(0, TimeUnit.SECONDS), 2)
+      .repeatAll(After.period(0, TimeUnit.SECONDS), 1)
+
+
+    builder.getInput.toList shouldBe List(
+      new StreamRecord[Integer](1, 0),
+      new StreamRecord[Integer](2, 1999),
+      new StreamRecord[Integer](1, 2000),
+      new StreamRecord[Integer](2, 3999),
+      new StreamRecord[Integer](1, 4000),
+      new StreamRecord[Integer](2, 5999),
+      new StreamRecord[Integer](1, 6000),
+      new StreamRecord[Integer](2, 7999),
+      new StreamRecord[Integer](1, 8000),
+      new StreamRecord[Integer](2, 9999),
+      new StreamRecord[Integer](1, 10000),
+      new StreamRecord[Integer](2, 11999)
+    )
+  }
+
+  it should "repeat elements with windows in front and back double repeat" in {
+    val builder = EventTimeInputBuilder.startWith(1, InWindow.to(2, TimeUnit.SECONDS))
+      .emit(2, InWindow.to(4, TimeUnit.SECONDS))
+      .repeatAll(After.period(0, TimeUnit.SECONDS), 2)
+      .repeatAll(After.period(0, TimeUnit.SECONDS), 1)
+
+    builder.getInput.toList shouldBe List(
+      new StreamRecord[Integer](1, 1999),
+      new StreamRecord[Integer](2, 3999),
+      new StreamRecord[Integer](1, 4000),
+      new StreamRecord[Integer](2, 5999),
+      new StreamRecord[Integer](1, 6000),
+      new StreamRecord[Integer](2, 7999),
+
+      new StreamRecord[Integer](1, 8000),
+      new StreamRecord[Integer](2, 9999),
+      new StreamRecord[Integer](1, 10000),
+      new StreamRecord[Integer](2, 11999),
+      new StreamRecord[Integer](1, 12000),
+      new StreamRecord[Integer](2, 13999)
+    )
+  }
+
+  it should "repeat elements with windows in front and back tripple repeat" in {
+    val builder = EventTimeInputBuilder.startWith(1, InWindow.to(2, TimeUnit.SECONDS))
+      .emit(2, InWindow.to(4, TimeUnit.SECONDS))
+      .repeatAll(After.period(0, TimeUnit.SECONDS), 2)
+      .repeatAll(After.period(0, TimeUnit.SECONDS), 2)
+
+    builder.getInput.toList shouldBe List(
+      new StreamRecord[Integer](1, 1999),
+      new StreamRecord[Integer](2, 3999),
+      new StreamRecord[Integer](1, 4000),
+      new StreamRecord[Integer](2, 5999),
+      new StreamRecord[Integer](1, 6000),
+      new StreamRecord[Integer](2, 7999),
+
+      new StreamRecord[Integer](1, 8000),
+      new StreamRecord[Integer](2, 9999),
+      new StreamRecord[Integer](1, 10000),
+      new StreamRecord[Integer](2, 11999),
+      new StreamRecord[Integer](1, 12000),
+      new StreamRecord[Integer](2, 13999),
+
+      new StreamRecord[Integer](1, 14000),
+      new StreamRecord[Integer](2, 15999),
+      new StreamRecord[Integer](1, 16000),
+      new StreamRecord[Integer](2, 17999),
+      new StreamRecord[Integer](1, 18000),
+      new StreamRecord[Integer](2, 19999)
+    )
+  }
+
 
 }


### PR DESCRIPTION
Fixed the semantics of repeating a list of input with InWindow statement.