### PR TITLE
Fixed tests not failing if no records are emitted.

### DIFF
--- a/flinkspector-core/src/main/java/io/flinkspector/core/runtime/OutputHandler.java
+++ b/flinkspector-core/src/main/java/io/flinkspector/core/runtime/OutputHandler.java
@@ -209,11 +209,21 @@ public class OutputHandler<OUT> implements Callable<OutputHandler.ResultState> {
                 break;
         }
 
+
         //check if all sink instances have been closed.
-        if (closedSinks.size() == parallelism &&
-                numRecords == expectedNumRecords) {
-            //finish the listening process
-            return Action.FINISH;
+
+        if(numRecords == expectedNumRecords) {
+            if (closedSinks.size() == parallelism) {
+                //finish the listening process
+                return Action.FINISH;
+
+            } else if(closedSinks.size() >= parallelism
+                    && expectedNumRecords == 0) {
+                //stream with no output will not open the sink
+                //so verifier has to be opened manually
+                verifier.init();
+                return Action.FINISH;
+            }
         }
         return Action.CONTINUE;
     }

--- a/flinkspector-core/src/test/scala/io/flinkspector/core/runtime/OutputHandlerSpec.scala
+++ b/flinkspector-core/src/test/scala/io/flinkspector/core/runtime/OutputHandlerSpec.scala
@@ -66,7 +66,7 @@ class OutputHandlerSpec extends CoreSpec {
 
     listener.call() shouldBe ResultState.SUCCESS
 
-    verify(verifier)
+    verify(verifier).init()
     verify(verifier).finish()
     close()
     listener.close()

--- a/flinkspector-core/src/test/scala/io/flinkspector/core/runtime/OutputHandlerSpec.scala
+++ b/flinkspector-core/src/test/scala/io/flinkspector/core/runtime/OutputHandlerSpec.scala
@@ -58,6 +58,20 @@ class OutputHandlerSpec extends CoreSpec {
     listener.close()
   }
 
+  it should "handle sinks which don't open" in new OutputListenerCase {
+    val listener = new OutputHandler[String](subscriber, disruptor, verifier, trigger)
+    disruptor.start()
+
+    publisher.send("CLOSE 0 0")
+
+    listener.call() shouldBe ResultState.SUCCESS
+
+    verify(verifier)
+    verify(verifier).finish()
+    close()
+    listener.close()
+  }
+
   it should "handle output from multiple sinks" in new OutputListenerCase {
     val listener = new OutputHandler[String](subscriber, disruptor, verifier, trigger)
     disruptor.start()

--- a/flinkspector-datastream/src/test/scala/io/flinkspector/datastream/StreamTestBaseSpec.scala
+++ b/flinkspector-datastream/src/test/scala/io/flinkspector/datastream/StreamTestBaseSpec.scala
@@ -18,6 +18,7 @@ package io.flinkspector.datastream
 
 import io.flinkspector.CoreSpec
 import io.flinkspector.core.collection.ExpectedRecords
+import org.apache.flink.api.common.functions.FilterFunction
 import org.apache.flink.streaming.api.datastream.DataStream
 
 import scala.collection.JavaConversions._
@@ -47,6 +48,21 @@ class StreamTestBaseSpec extends CoreSpec {
     base.assertStream(stream, matcher)
     an[AssertionError] shouldBe thrownBy(base.executeTest())
   }
+
+  it should "fail a test without output" in {
+    val base = new DataStreamTestBase
+    base.initialize()
+
+    val coll: java.util.Collection[Int] = List(1, 2, 3, 4)
+    val stream: DataStream[Int] = base.createTestStream(List(1))
+    val matcher = ExpectedRecords.create(coll)
+
+    base.assertStream(stream.filter(new FilterFunction[Int] {
+      override def filter(t: Int): Boolean = false
+    }), matcher)
+    an[AssertionError] shouldBe thrownBy(base.executeTest())
+  }
+
 
 
   it should "run a basic test with two sinks" in {


### PR DESCRIPTION
This fixes issue #55 the problem was that the sink will not send an open message if no output is produced. This can potentially also be fixed by changing the protocol. 