### PR TITLE
Allow multiple scala versions

### DIFF
--- a/flinkspector-core/pom.xml
+++ b/flinkspector-core/pom.xml
@@ -20,12 +20,12 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.flinkspector</groupId>
-        <artifactId>flinkspector-parent_2.11</artifactId>
+        <artifactId>flinkspector-parent_${scala.binary.version}</artifactId>
         <version>0.9.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>flinkspector-core_2.11</artifactId>
+    <artifactId>flinkspector-core_${scala.binary.version}</artifactId>
     <name>flinkspector-core</name>
 
     <packaging>jar</packaging>

--- a/flinkspector-dataset/pom.xml
+++ b/flinkspector-dataset/pom.xml
@@ -20,12 +20,12 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.flinkspector</groupId>
-        <artifactId>flinkspector-parent_2.11</artifactId>
+        <artifactId>flinkspector-parent_${scala.binary.version}</artifactId>
         <version>0.9.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>flinkspector-dataset_2.11</artifactId>
+    <artifactId>flinkspector-dataset_${scala.binary.version}</artifactId>
     <name>flinkspector-dataset</name>
 
     <packaging>jar</packaging>

--- a/flinkspector-datastream/pom.xml
+++ b/flinkspector-datastream/pom.xml
@@ -20,12 +20,12 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.flinkspector</groupId>
-        <artifactId>flinkspector-parent_2.11</artifactId>
+        <artifactId>flinkspector-parent_${scala.binary.version}</artifactId>
         <version>0.9.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>flinkspector-datastream_2.11</artifactId>
+    <artifactId>flinkspector-datastream_${scala.binary.version}</artifactId>
     <name>flinkspector-datastream</name>
 
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.flinkspector</groupId>
-    <artifactId>flinkspector-parent_2.11</artifactId>
+    <artifactId>flinkspector-parent_${scala.binary.version}</artifactId>
     <version>0.9.3-SNAPSHOT</version>
 
     <name>Flinkspector</name>


### PR DESCRIPTION
At the moment is impossible to target scala 2.12 because the sub modules hardcoded the scala binary version in their pom rather than using the property, with this change is possible to build Flink-spector against scala 2.12, tested from the command line:  `mvn clean package -Dscala.version=2.12 -Dscala.binary.version=2.12`
I guess next step would be to publish also 2.12 in maven.